### PR TITLE
Fixed orientation change rebuilding article view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         <activity
                 android:name=".ArticleView"
                 android:parentActivityName=".MainActivity"
-                android:theme="@style/AppTheme.NoActionBar">
+                android:theme="@style/AppTheme.NoActionBar"
+                android:configChanges="orientation|screenSize">
             <meta-data
                     android:name="android.support.PARENT_ACTIVITY"
                     android:value=".MainActivity"/>


### PR DESCRIPTION
This prevents the article view from being rebuilt on an orientation change. Just a little annoyance. Thus on a multiple-side article, you stay on the same page when changing the devices orientation.