### PR TITLE
Workaround for #31

### DIFF
--- a/app/src/main/java/de/eknoes/inofficialgolem/ArticleFragment.java
+++ b/app/src/main/java/de/eknoes/inofficialgolem/ArticleFragment.java
@@ -189,10 +189,10 @@ public class ArticleFragment extends Fragment {
         int id = item.getItemId();
 
         if (id == R.id.action_open) {
-            Intent webIntent = new Intent(Intent.ACTION_VIEW);
             if (url != null) {
-                webIntent.setData(Uri.parse(url));
-                startActivity(webIntent);
+                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(Intent.createChooser(intent, "Select Browser"));
             }
         } else if (id == R.id.action_comments) {
             Log.d(TAG, "onOptionsItemSelected: Open Comments: " + article.getCommentUrl());
@@ -257,7 +257,7 @@ public class ArticleFragment extends Fragment {
 
         @Override
         protected Void doInBackground(Void... params) {
-                FeedReaderDbHelper dbHelper = FeedReaderDbHelper.getInstance(Objects.requireNonNull(getContext()).getApplicationContext());
+                FeedReaderDbHelper dbHelper = FeedReaderDbHelper.getInstance(requireContext().getApplicationContext());
 
                 SQLiteDatabase db = dbHelper.getReadableDatabase();
 


### PR DESCRIPTION
Instead of opening the URL in the app, an app selector is shown that allows for opening the URL in a browser

I would consider this a workaround and not a fix, since the default browser is not automatically used to open the URL